### PR TITLE
rev up virtualbox 5.1

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class virtualbox::params {
 
   case $::osfamily {
     'Debian': {
-      $version = '5.0'
+      $version = '5.1'
       $manage_kernel = true
       $manage_package = true
       $package_ensure = present
@@ -30,7 +30,7 @@ class virtualbox::params {
 
     }
     'RedHat': {
-      $version = '5.0'
+      $version = '5.1'
       $manage_kernel = true
       $manage_package = true
       $manage_repo = true
@@ -50,7 +50,7 @@ class virtualbox::params {
     }
     'Suse': {
       warning('Careful! Support for SuSE is experimental at best.')
-      $version = '5.0'
+      $version = '5.1'
       $manage_kernel = true
       $manage_package = true
       $manage_repo = true

--- a/spec/acceptance/02_virtualbox_extpack_spec.rb
+++ b/spec/acceptance/02_virtualbox_extpack_spec.rb
@@ -9,7 +9,7 @@ describe 'virtualbox extpack' do
 
     virtualbox::extpack { 'Oracle_VM_VirtualBox_Extension_Pack':
       ensure           => present,
-      source           => 'http://download.virtualbox.org/virtualbox/5.0.16/Oracle_VM_VirtualBox_Extension_Pack-5.0.16-105871.vbox-extpack',
+      source           => 'http://download.virtualbox.org/virtualbox/5.1.8/Oracle_VM_VirtualBox_Extension_Pack-5.1.8-111374.vbox-extpack',
       checksum_string  => '41f1d66e0be1c183917c95efed89db56',
       follow_redirects => true,
     }
@@ -22,7 +22,7 @@ describe 'virtualbox extpack' do
 
     virtualbox::extpack { 'Oracle_VM_VirtualBox_Extension_Pack':
       ensure           => absent,
-      source           => 'http://download.virtualbox.org/virtualbox/5.0.16/Oracle_VM_VirtualBox_Extension_Pack-5.0.16-105871.vbox-extpack',
+      source           => 'http://download.virtualbox.org/virtualbox/5.1.8/Oracle_VM_VirtualBox_Extension_Pack-5.1.8-111374.vbox-extpack',
       checksum_string  => '41f1d66e0be1c183917c95efed89db56',
       follow_redirects => true,
     }


### PR DESCRIPTION
**UPATED DUE TO MOVE TO VOX**
Changes:
- setting default version to virtualbox 5.1 (previously 5.0)

Reason for the change(s):
Rev up to Virtualbox 5.1: with the discovery of the Dirty COW (CVE-2016-5195) main stream distributions are releasing patched kernels, unfortunately the bleeding edge kernels are not supported on 5.0, but 5.1 is supported. This means for updated servers to function with this module they must be on version 5.1
