### PR TITLE
Migrate init.pp to puppet 4

### DIFF
--- a/manifests/extpack.pp
+++ b/manifests/extpack.pp
@@ -46,7 +46,7 @@ define virtualbox::extpack (
   if $verify_checksum {
     $_checksum_type   = $checksum_type
     $_checksum_string = $checksum_string
-  }  else {
+  } else {
     $_checksum_type   = undef
     $_checksum_string = undef
   }

--- a/manifests/extpack.pp
+++ b/manifests/extpack.pp
@@ -4,11 +4,11 @@
 #
 # === Parameters
 #
+# [*source*]
+#   Download extension pack from the given URL. Required string.
 # [*ensure*]
 #   Set to 'present' to install extension pack. Set to 'absent' to uninstall.
 #   Defaults to 'present'
-# [*source*]
-#   Download extension pack from the given URL. Required string.
 # [*verify_checksum*]
 #   Whether to verify the checksum of the downloaded file. Optional boolean.
 #   Defaults to true.
@@ -30,56 +30,43 @@
 #   This can be set to the Puppet Forge username of the developer of the
 #   `archive` module you wish to use. If a falsey value is passed, this module
 #   will try and determine the module author by using the `load_module_metadata`
-#   function from Stdlib. This is the default behavior. Defaults to `false`.
+#   function from Stdlib. This is the default behavior. Defaults to `undef`.
 #
 define virtualbox::extpack (
-  $source,
-  $ensure           = present,
-  $verify_checksum  = true,
-  $checksum_string  = undef,
-  $checksum_type    = 'md5',
-  $follow_redirects = false,
-  $extpack_path     = '/usr/lib/virtualbox/ExtensionPacks',
-  $archive_provider = false,
+  String $source,
+  Enum['present', 'absent'] $ensure                                                       = 'present',
+  Boolean $verify_checksum                                                                = true,
+  Optional[String] $checksum_string                                                       = undef,
+  Enum['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'] $checksum_type              = 'md5',
+  Boolean $follow_redirects                                                               = false,
+  Stdlib::Absolutepath $extpack_path                                                      = '/usr/lib/virtualbox/ExtensionPacks',
+  Optional[Enum['puppet','puppet-community','voxpupuli','camptocamp']] $archive_provider  = undef,
 ) {
 
-  validate_re($ensure, ['^present$', '^absent$'])
-  validate_string($source)
-  validate_absolute_path($extpack_path)
-  validate_bool($follow_redirects)
-
-  $_verify_checksum = str2bool($verify_checksum)
-
-  if $_verify_checksum {
-    validate_re($checksum_type, ['^md5', '^sha1', '^sha224', '^sha256', '^sha384', '^sha512'])
-    validate_string($checksum_string)
-
+  if $verify_checksum {
     $_checksum_type   = $checksum_type
     $_checksum_string = $checksum_string
-  } else {
+  }  else {
     $_checksum_type   = undef
     $_checksum_string = undef
   }
 
   $dest = "${extpack_path}/${name}"
 
-  if $archive_provider {
-    validate_re($archive_provider, ['^puppet$', '^puppet-community$', '^voxpupuli$', '^camptocamp$'])
-    $_provider = $archive_provider
-  } else {
+  unless $archive_provider {
     $metadata = load_module_metadata('archive')
-    $_provider = $metadata['source'] ? {
+    $archive_provider = $metadata['source'] ? {
       /github\.com\/camptocamp/                   => 'camptocamp',
       /github\.com\/(puppet-community|voxpupuli)/ => 'voxpupuli',
     }
   }
 
-  case $_provider {
+  case $archive_provider {
     'camptocamp': {
       archive::download { "${name}.tgz":
         ensure           => $ensure,
         url              => $source,
-        checksum         => $_verify_checksum,
+        checksum         => $verify_checksum,
         digest_type      => $_checksum_type,
         digest_string    => $_checksum_string,
         follow_redirects => $follow_redirects,
@@ -100,7 +87,7 @@ define virtualbox::extpack (
         source          => $source,
         checksum        => $_checksum_string,
         checksum_type   => $_checksum_type,
-        checksum_verify => $_verify_checksum,
+        checksum_verify => $verify_checksum,
         extract         => false,
         require         => Class['virtualbox'],
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,7 +60,6 @@ class virtualbox (
   class { '::virtualbox::install': } -> Class['virtualbox']
 
   if $manage_kernel {
-    validate_array($vboxdrv_dependencies)
     Class['virtualbox::install'] -> class { '::virtualbox::kernel': }
 
     if $::osfamily == 'RedHat' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,6 +18,8 @@
 #   On applicable platforms, should this module manage the external dependency
 #   repository when `manage_kernel` is set to true?
 #   Defaults to true
+# [*repo_proxy*]
+#   Defaults to undef
 # [*manage_package*]
 #   Should this module manage the package?
 #   Defaults to true
@@ -34,15 +36,15 @@
 #   Defaults to 'VirtualBox' for RedHat and 'virtualbox' for Debian
 #
 class virtualbox (
-  $version              = $virtualbox::params::version,
-  $package_ensure       = $virtualbox::params::package_ensure,
-  $manage_repo          = $virtualbox::params::manage_repo,
-  $manage_ext_repo      = $virtualbox::params::manage_ext_repo,
-  $repo_proxy           = $virtualbox::params::repo_proxy,
-  $manage_package       = $virtualbox::params::manage_package,
-  $manage_kernel        = $virtualbox::params::manage_kernel,
-  $vboxdrv_dependencies = $virtualbox::params::vboxdrv_dependencies,
-  $package_name         = $virtualbox::params::package_name
+  String $version               = $virtualbox::params::version,
+  String $package_ensure        = $virtualbox::params::package_ensure,
+  Boolean $manage_repo          = $virtualbox::params::manage_repo,
+  Boolean $manage_ext_repo      = $virtualbox::params::manage_ext_repo,
+  Optional[String] $repo_proxy  = $virtualbox::params::repo_proxy,
+  Boolean $manage_package       = $virtualbox::params::manage_package,
+  Boolean $manage_kernel        = $virtualbox::params::manage_kernel,
+  Array $vboxdrv_dependencies   = $virtualbox::params::vboxdrv_dependencies,
+  String $package_name          = $virtualbox::params::package_name
 ) inherits virtualbox::params {
 
   if versioncmp($::puppetversion, '4.0.0') == -1 {
@@ -54,12 +56,6 @@ class virtualbox (
   } else {
     $vboxdrv_command = '/usr/lib/virtualbox/vboxdrv.sh'
   }
-
-  validate_bool($manage_repo)
-  validate_bool($manage_ext_repo)
-  validate_bool($manage_package)
-  validate_bool($manage_kernel)
-  validate_string($package_name)
 
   class { '::virtualbox::install': } -> Class['virtualbox']
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,12 +5,12 @@
 # also install a package repository.
 #
 class virtualbox::install (
-  $version        = $virtualbox::version,
-  $package_ensure = $virtualbox::package_ensure,
-  $package_name   = $virtualbox::package_name,
-  $manage_repo    = $virtualbox::manage_repo,
-  $repo_proxy     = $virtualbox::repo_proxy,
-  $manage_package = $virtualbox::manage_package
+  String $version               = $virtualbox::version,
+  String $package_ensure        = $virtualbox::package_ensure,
+  String $package_name          = $virtualbox::package_name,
+  Boolean $manage_repo          = $virtualbox::manage_repo,
+  Optional[String] $repo_proxy  = $virtualbox::repo_proxy,
+  Boolean $manage_package       = $virtualbox::manage_package
 ) {
 
   if $package_name == $::virtualbox::params::package_name {

--- a/manifests/kernel.pp
+++ b/manifests/kernel.pp
@@ -5,9 +5,9 @@
 # dependencies.
 #
 class virtualbox::kernel (
-  $manage_repo          = $virtualbox::manage_repo,
-  $vboxdrv_dependencies = $virtualbox::vboxdrv_dependencies,
-  $vboxdrv_command      = $virtualbox::vboxdrv_command
+  Boolean $manage_repo        = $virtualbox::manage_repo,
+  Array $vboxdrv_dependencies = $virtualbox::vboxdrv_dependencies,
+  String $vboxdrv_command     = $virtualbox::vboxdrv_command
 ) {
 
   ensure_packages($vboxdrv_dependencies)

--- a/metadata.json
+++ b/metadata.json
@@ -49,7 +49,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.8.0 <5.0.0"
+      "version_requirement": ">= 4.13.1 <5.0.0"
     },
     {
       "name": "puppetlabs/apt",

--- a/spec/defines/virtualbox__extpack_spec.rb
+++ b/spec/defines/virtualbox__extpack_spec.rb
@@ -67,7 +67,6 @@ describe 'virtualbox::extpack' do
       it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_digest_string(nil) }
       it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
     end
-
   end
 
   context 'with voxpupuli/archive' do
@@ -100,6 +99,5 @@ describe 'virtualbox::extpack' do
       it { is_expected.to contain_archive('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum_type(nil) }
       it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
     end
-
   end
 end

--- a/spec/defines/virtualbox__extpack_spec.rb
+++ b/spec/defines/virtualbox__extpack_spec.rb
@@ -36,12 +36,6 @@ describe 'virtualbox::extpack' do
     end
   end
 
-  context 'with unsupported archive module' do
-    let(:provider) { 'fubar' }
-    let(:params) { sane_defaults }
-    it { is_expected.to raise_error(Puppet::Error, %r{does not match}) }
-  end
-
   context 'with camptocamp/archive' do
     let(:provider) { 'camptocamp' }
     include_context 'archive fixtures'
@@ -74,10 +68,6 @@ describe 'virtualbox::extpack' do
       it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
     end
 
-    context 'with bad checksum type' do
-      let(:params) { sane_defaults.merge(checksum_type: 'invalid') }
-      it { is_expected.to raise_error(Puppet::Error, %r{does not match}) }
-    end
   end
 
   context 'with voxpupuli/archive' do
@@ -111,9 +101,5 @@ describe 'virtualbox::extpack' do
       it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
     end
 
-    context 'with bad checksum type' do
-      let(:params) { sane_defaults.merge(checksum_type: 'invalid') }
-      it { is_expected.to raise_error(Puppet::Error, %r{does not match}) }
-    end
   end
 end


### PR DESCRIPTION
Add data types to parameters, remove 'validate_' functions, remove unnecessary tests, and change default value of extpack's $archive_provider from 'false' to 'undef'.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
