### PR TITLE
Recognize Debian Stretch

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,7 +34,7 @@ class virtualbox::install (
         }
 
         case $::lsbdistcodename {
-          /^(jessie|xenial)$/: {
+          /^(jessie|stretch|xenial)$/: {
             $apt_key_thumb  = 'B9F8D658297AF3EFC18D5CDFA2F683C52980AECF'
             $apt_key_source = 'https://www.virtualbox.org/download/oracle_vbox_2016.asc'
           }

--- a/metadata.json
+++ b/metadata.json
@@ -36,7 +36,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     }
   ],


### PR DESCRIPTION
Debian 9 ("Stretch") was released on June 17, 2017 and requires the 2016
signing key.