### PR TITLE
Add bionic to the apt::key regexp to support Ubuntu 18.04

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,7 +34,7 @@ class virtualbox::install (
         }
 
         case $::lsbdistcodename {
-          /^(jessie|stretch|xenial)$/: {
+          /^(jessie|stretch|xenial|bionic)$/: {
             $apt_key_thumb  = 'B9F8D658297AF3EFC18D5CDFA2F683C52980AECF'
             $apt_key_source = 'https://www.virtualbox.org/download/oracle_vbox_2016.asc'
           }

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,8 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+        "16.04",
+        "18.04"
       ]
     },
     {


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Add bionic in a regexp used with apt::key to install the right repository key for Ubuntu 18.04

#### This Pull Request (PR) fixes the following issues
    Fixes #82 