### PR TITLE
Drop support for camptocamp archive provider

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,6 @@
 fixtures:
   repositories:
+    archive: "https://github.com/voxpupuli/puppet-archive.git"
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     apt: "https://github.com/puppetlabs/puppetlabs-apt.git"
     epel: "https://github.com/voxpupuli/puppet-epel.git"

--- a/.sync.yml
+++ b/.sync.yml
@@ -3,7 +3,3 @@
   secure: "mfTBE/J94XtpQ3O7WWmgiGW9wBNV2zJlj33914lUeprD+mmR4nQzXVbZGa0hRjaGpwcW1cZszDPin9VkueESVOOlwQIX0+p5NTn+U3TJO5ea6UMVAzS1pOpgCuOZ5JjEneaIscQLwAZ7BBYeP+Kov/24oh4OhBPQ0OW+w1uNAKk="
 spec/spec_helper.rb:
   spec_overrides: "require 'spec_helper_methods'"
-Gemfile:
-  optional:
-    ':system_tests':
-      - gem: 'beaker-vagrant'

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,5 +1,3 @@
 ---
 .travis.yml:
   secure: "mfTBE/J94XtpQ3O7WWmgiGW9wBNV2zJlj33914lUeprD+mmR4nQzXVbZGa0hRjaGpwcW1cZszDPin9VkueESVOOlwQIX0+p5NTn+U3TJO5ea6UMVAzS1pOpgCuOZ5JjEneaIscQLwAZ7BBYeP+Kov/24oh4OhBPQ0OW+w1uNAKk="
-spec/spec_helper.rb:
-  spec_overrides: "require 'spec_helper_methods'"

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ end
 
 group :system_tests do
   gem 'voxpupuli-acceptance',  :require => false
-  gem 'beaker-vagrant',        :require => false
 end
 
 group :release do

--- a/README.md
+++ b/README.md
@@ -89,16 +89,15 @@ class { 'virtualbox':
 
 ### Extension Pack
 
-NOTE: To use this feature, you must have either [camptocamp/archive](https://forge.puppet.com/camptocamp/archive) or [puppet/archive](https://forge.puppet.com/puppet/archive) installed.
+NOTE: To use this feature, you must have [puppet/archive](https://forge.puppet.com/puppet/archive) installed.
 
 There's a defined type to install an Extension Pack. I'm not aware of any extension packs other than the Oracle Extension Pack, but this type should work for third party extensions. You can install Oracle's Extension Pack (adding support for USB 2.0, access to webcam, RDP and E1000 PXE ROM) like so:
 
 ```puppet
   virtualbox::extpack { 'Oracle_VM_VirtualBox_Extension_Pack':
-    ensure           => present,
-    source           => 'http://download.virtualbox.org/virtualbox/6.0.0_RC1/Oracle_VM_VirtualBox_Extension_Pack-6.0.0_RC1.vbox-extpack',
-    checksum_string  => 'deecf9b15ffda29d4d5da4349763fd11',
-    follow_redirects => true,
+    ensure          => present,
+    source          => 'http://download.virtualbox.org/virtualbox/6.0.0_RC1/Oracle_VM_VirtualBox_Extension_Pack-6.0.0_RC1.vbox-extpack',
+    checksum_string => 'deecf9b15ffda29d4d5da4349763fd11',
   }
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -165,15 +165,6 @@ checksum. Can be md5, sha1, sha224, sha256, sha384, or sha512. Defaults to
 
 Default value: `'md5'`
 
-##### `follow_redirects`
-
-Data type: `Boolean`
-
-If we should follow HTTP redirects. Ignored when using `puppet/archive`.
-Defaults to false.
-
-Default value: ``false``
-
 ##### `extpack_path`
 
 Data type: `Stdlib::Absolutepath`
@@ -182,16 +173,4 @@ This is the path where VirtualBox looks for extension packs. Defaults to
 '/usr/lib/virtualbox/ExtensionPacks'
 
 Default value: `'/usr/lib/virtualbox/ExtensionPacks'`
-
-##### `archive_provider`
-
-Data type: `Optional[Enum['puppet','puppet-community','voxpupuli','camptocamp']]`
-
-This param eter is used to tell the module which `archive` module to expect.
-This can be set to the Puppet Forge username of the developer of the
-`archive` module you wish to use. If a falsey value is passed, this module
-will try and determine the module author by using the `load_module_metadata`
-function from Stdlib. This is the default behavior. Defaults to `undef`.
-
-Default value: ``undef``
 

--- a/manifests/extpack.pp
+++ b/manifests/extpack.pp
@@ -15,28 +15,16 @@
 #   If $verify_checksum is true, this is the algorithm to use to validate the
 #   checksum. Can be md5, sha1, sha224, sha256, sha384, or sha512. Defaults to
 #   'md5'
-# @param follow_redirects
-#   If we should follow HTTP redirects. Ignored when using `puppet/archive`.
-#   Defaults to false.
 # @param extpack_path
 #   This is the path where VirtualBox looks for extension packs. Defaults to
 #   '/usr/lib/virtualbox/ExtensionPacks'
-# @param archive_provider
-#   This param eter is used to tell the module which `archive` module to expect.
-#   This can be set to the Puppet Forge username of the developer of the
-#   `archive` module you wish to use. If a falsey value is passed, this module
-#   will try and determine the module author by using the `load_module_metadata`
-#   function from Stdlib. This is the default behavior. Defaults to `undef`.
-#
 define virtualbox::extpack (
   String $source,
   Enum['present', 'absent'] $ensure                                                       = 'present',
   Boolean $verify_checksum                                                                = true,
   Optional[String] $checksum_string                                                       = undef,
   Enum['md5', 'sha1', 'sha224', 'sha256', 'sha384', 'sha512'] $checksum_type              = 'md5',
-  Boolean $follow_redirects                                                               = false,
   Stdlib::Absolutepath $extpack_path                                                      = '/usr/lib/virtualbox/ExtensionPacks',
-  Optional[Enum['puppet','puppet-community','voxpupuli','camptocamp']] $archive_provider  = undef,
 ) {
   if $verify_checksum {
     $_checksum_type   = $checksum_type
@@ -48,53 +36,14 @@ define virtualbox::extpack (
 
   $dest = "${extpack_path}/${name}"
 
-  if $archive_provider {
-    $valid_archive_provider = $archive_provider
-  } else {
-    $metadata = load_module_metadata('archive')
-    $valid_archive_provider = $metadata['source'] ? {
-      /github\.com\/camptocamp/                   => 'camptocamp',
-      /github\.com\/(puppet-community|voxpupuli)/ => 'voxpupuli',
-    }
-  }
-
-  case $valid_archive_provider {
-    'camptocamp': {
-      warning 'Support for module camptocamp/archive is deprecated. Futur version of this module will only support puppet/archive.'
-      archive::download { "${name}.tgz":
-        ensure           => $ensure,
-        url              => $source,
-        checksum         => $verify_checksum,
-        digest_type      => $_checksum_type,
-        digest_string    => $_checksum_string,
-        follow_redirects => $follow_redirects,
-        require          => Class['virtualbox'],
-      }
-
-      if $ensure =~ /^present$/ {
-        Archive::Download["${name}.tgz"] -> Exec["${name} unpack"]
-      }
-    }
-    /^(voxpupuli|puppet-community|puppet)$/: {
-      unless $follow_redirects {
-        warning("The puppet/archive module does not support the \$follow_redirects parameter.")
-      }
-
-      archive { "/usr/src/${name}.tgz":
-        ensure          => $ensure,
-        source          => $source,
-        checksum        => $_checksum_string,
-        checksum_type   => $_checksum_type,
-        checksum_verify => $verify_checksum,
-        extract         => false,
-        require         => Class['virtualbox'],
-      }
-
-      if $ensure =~ /^present$/ {
-        Archive["/usr/src/${name}.tgz"] -> Exec["${name} unpack"]
-      }
-    }
-    default: { fail('Unknown Archive module. Please install puppet/archive or camptocamp/archive.') }
+  archive { "/usr/src/${name}.tgz":
+    ensure          => $ensure,
+    source          => $source,
+    checksum        => $_checksum_string,
+    checksum_type   => $_checksum_type,
+    checksum_verify => $verify_checksum,
+    extract         => false,
+    require         => Class['virtualbox'],
   }
 
   case $ensure {
@@ -104,6 +53,7 @@ define virtualbox::extpack (
         creates => $dest,
         timeout => 120,
         path    => $::path,
+        require => Archive["/usr/src/${name}.tgz"],
       }
     }
     'absent': {

--- a/spec/acceptance/02_virtualbox_extpack_spec.rb
+++ b/spec/acceptance/02_virtualbox_extpack_spec.rb
@@ -1,17 +1,14 @@
 require 'spec_helper_acceptance'
 
-authors = %w[camptocamp puppet]
-
 describe 'virtualbox extpack' do
   let(:install) do
     <<-EOS
     include virtualbox
 
     virtualbox::extpack { 'Oracle_VM_VirtualBox_Extension_Pack':
-      ensure           => present,
-      source           => 'http://download.virtualbox.org/virtualbox/6.0.0_RC1/Oracle_VM_VirtualBox_Extension_Pack-6.0.0_RC1.vbox-extpack',
-      checksum_string  => 'deecf9b15ffda29d4d5da4349763fd11',
-      follow_redirects => true,
+      ensure          => present,
+      source          => 'http://download.virtualbox.org/virtualbox/6.0.0_RC1/Oracle_VM_VirtualBox_Extension_Pack-6.0.0_RC1.vbox-extpack',
+      checksum_string => 'deecf9b15ffda29d4d5da4349763fd11',
     }
     EOS
   end
@@ -21,67 +18,52 @@ describe 'virtualbox extpack' do
     include virtualbox
 
     virtualbox::extpack { 'Oracle_VM_VirtualBox_Extension_Pack':
-      ensure           => absent,
-      source           => 'http://download.virtualbox.org/virtualbox/6.0.0_RC1/Oracle_VM_VirtualBox_Extension_Pack-6.0.0_RC1.vbox-extpack',
-      checksum_string  => 'deecf9b15ffda29d4d5da4349763fd11',
-      follow_redirects => true,
+      ensure          => absent,
+      source          => 'http://download.virtualbox.org/virtualbox/6.0.0_RC1/Oracle_VM_VirtualBox_Extension_Pack-6.0.0_RC1.vbox-extpack',
+      checksum_string => 'deecf9b15ffda29d4d5da4349763fd11',
     }
     EOS
   end
 
-  authors.each do |author|
-    context "with #{author}/archive" do
-      before(:all) do
-        hosts.each do |host|
-          authors.each do |author2|
-            on host, puppet('module', 'uninstall', '-f', "#{author2}-archive"), acceptable_exit_codes: [0, 1]
-          end
+  context 'install extpack' do
+    it 'is idempotent' do
+      apply_manifest(install, catch_failures: true)
+      apply_manifest(install, catch_changes: true)
+    end
 
-          on host, puppet('module', 'install', "#{author}-archive")
-        end
-      end
+    describe file('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') do
+      it { is_expected.to be_directory }
+    end
 
-      context 'install extpack' do
-        it 'is idempotent' do
-          apply_manifest(install, catch_failures: true)
-          apply_manifest(install, catch_changes: true)
-        end
+    describe file('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz') do
+      it { is_expected.to be_file }
+      its(:md5sum) { is_expected.to eq 'deecf9b15ffda29d4d5da4349763fd11' }
+    end
 
-        describe file('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') do
-          it { is_expected.to be_directory }
-        end
+    describe command('VBoxManage list extpacks') do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match %r{Extension Packs: 1} }
+    end
+  end
 
-        describe file('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz') do
-          it { is_expected.to be_file }
-          its(:md5sum) { is_expected.to eq 'deecf9b15ffda29d4d5da4349763fd11' }
-        end
+  context 'uninstall extpack' do
+    it 'is idempotent' do
+      apply_manifest(install, catch_failures: true)
+      apply_manifest(uninstall, catch_failures: true)
+      apply_manifest(uninstall, catch_changes: true)
+    end
 
-        describe command('VBoxManage list extpacks') do
-          its(:exit_status) { is_expected.to eq 0 }
-          its(:stdout) { is_expected.to match %r{Extension Packs: 1} }
-        end
-      end
+    describe file('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') do
+      it { is_expected.not_to be_directory }
+    end
 
-      context 'uninstall extpack' do
-        it 'is idempotent' do
-          apply_manifest(install, catch_failures: true)
-          apply_manifest(uninstall, catch_failures: true)
-          apply_manifest(uninstall, catch_changes: true)
-        end
+    describe file('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz') do
+      it { is_expected.not_to be_file }
+    end
 
-        describe file('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') do
-          it { is_expected.not_to be_directory }
-        end
-
-        describe file('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz') do
-          it { is_expected.not_to be_file }
-        end
-
-        describe command('VBoxManage list extpacks') do
-          its(:exit_status) { is_expected.to eq 0 }
-          its(:stdout) { is_expected.to match %r{Extension Packs: 0} }
-        end
-      end
+    describe command('VBoxManage list extpacks') do
+      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match %r{Extension Packs: 0} }
     end
   end
 end

--- a/spec/defines/virtualbox__extpack_spec.rb
+++ b/spec/defines/virtualbox__extpack_spec.rb
@@ -1,6 +1,4 @@
 require 'spec_helper'
-require 'puppetlabs_spec_helper/rake_tasks'
-require 'fileutils'
 
 describe 'virtualbox::extpack' do
   on_supported_os.each do |os, os_facts|
@@ -14,91 +12,37 @@ describe 'virtualbox::extpack' do
         {
           ensure: 'present',
           source: 'http://server.example.com/extpack.vbox-extpack',
-          checksum_string: 'd41d8cd98f00b204e9800998ecf8427e',
-          archive_provider: provider
+          checksum_string: 'd41d8cd98f00b204e9800998ecf8427e'
         }
       end
 
-      shared_context 'archive fixtures' do
-        before(:all) do # rubocop:disable RSpec/BeforeAfterAll
-          FileUtils.rm_rf "#{fixture_path}/modules/archive"
-        end
+      context 'with defaults' do
+        let(:params) { sane_defaults }
 
-        before do
-          mod = "#{fixture_path}/modules/archive"
-          clone_repo('git', "https://github.com/#{provider}/puppet-archive", mod) unless File.directory? mod
-        end
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_archive('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum('d41d8cd98f00b204e9800998ecf8427e') }
+        it { is_expected.to contain_archive('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum_type('md5') }
+        it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
+        it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').that_requires('Archive[/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz]') }
       end
 
-      context 'with camptocamp/archive' do
-        let(:provider) { 'camptocamp' }
+      context 'with ensure => absent' do
+        let(:params) { sane_defaults.merge(ensure: 'absent') }
 
-        include_context 'archive fixtures'
-
-        context 'with defaults' do
-          let(:params) { sane_defaults }
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum(true) }
-          it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_digest_string('d41d8cd98f00b204e9800998ecf8427e') }
-          it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_digest_type('md5') }
-          it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
-          it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').that_requires('Archive::Download[Oracle_VM_VirtualBox_Extension_Pack.tgz]') }
-        end
-
-        context 'with ensure => absent' do
-          let(:params) { sane_defaults.merge(ensure: 'absent') }
-
-          it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_ensure('absent') }
-          it { is_expected.to contain_file('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack').with_ensure('absent') }
-        end
-
-        context 'with $verify_checksum => false' do
-          let(:params) do
-            sane_defaults.merge(verify_checksum: false,
-                                checksum_type: 'sha1')
-          end
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum(false) }
-          it { is_expected.to contain_archive__download('Oracle_VM_VirtualBox_Extension_Pack.tgz').with_digest_string(nil) }
-          it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
-        end
+        it { is_expected.to contain_archive('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_ensure('absent') }
+        it { is_expected.to contain_file('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack').with_ensure('absent') }
       end
 
-      context 'with voxpupuli/archive' do
-        let(:provider) { 'voxpupuli' }
-
-        include_context 'archive fixtures'
-
-        context 'with defaults' do
-          let(:params) { sane_defaults }
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_archive('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum('d41d8cd98f00b204e9800998ecf8427e') }
-          it { is_expected.to contain_archive('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum_type('md5') }
-          it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
-          it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').that_requires('Archive[/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz]') }
+      context 'with $verify_checksum => false' do
+        let(:params) do
+          sane_defaults.merge(verify_checksum: false,
+                              checksum_type: 'sha1')
         end
 
-        context 'with ensure => absent' do
-          let(:params) { sane_defaults.merge(ensure: 'absent') }
-
-          it { is_expected.to contain_archive('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_ensure('absent') }
-          it { is_expected.to contain_file('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack').with_ensure('absent') }
-        end
-
-        context 'with $verify_checksum => false' do
-          let(:params) do
-            sane_defaults.merge(verify_checksum: false,
-                                checksum_type: 'sha1')
-          end
-
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_archive('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum(nil) }
-          it { is_expected.to contain_archive('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum_type(nil) }
-          it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
-        end
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_archive('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum(nil) }
+        it { is_expected.to contain_archive('/usr/src/Oracle_VM_VirtualBox_Extension_Pack.tgz').with_checksum_type(nil) }
+        it { is_expected.to contain_exec('Oracle_VM_VirtualBox_Extension_Pack unpack').with_creates('/usr/lib/virtualbox/ExtensionPacks/Oracle_VM_VirtualBox_Extension_Pack') }
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,5 +16,3 @@ if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
     end
   end
 end
-
-require 'spec_helper_methods'

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,8 @@
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
-configure_beaker
+configure_beaker do |host|
+  on host, puppet('module', 'install', 'puppet-archive')
+end
 
 shared_examples 'an idempotent puppet code' do
   it 'applies without error' do

--- a/spec/spec_helper_methods.rb
+++ b/spec/spec_helper_methods.rb
@@ -1,3 +1,0 @@
-def fixture_path
-  File.expand_path(File.join(__FILE__, '..', 'fixtures'))
-end


### PR DESCRIPTION
This module has been archived and was already deprecated. Dropping this simplifies the module.