### PR TITLE
Update yum repository signing key

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -66,7 +66,7 @@ class virtualbox::install (
         yumrepo { 'virtualbox':
           descr    => 'Oracle Linux / RHEL / CentOS-$releasever / $basearch - VirtualBox',
           baseurl  => "https://download.virtualbox.org/virtualbox/rpm/${platform}/\$releasever/\$basearch",
-          gpgkey   => 'https://www.virtualbox.org/download/oracle_vbox.asc',
+          gpgkey   => 'https://www.virtualbox.org/download/oracle_vbox_2016.asc',
           gpgcheck => 1,
           enabled  => 1,
           proxy    => $repo_proxy,

--- a/spec/acceptance/01_virtualbox_spec.rb
+++ b/spec/acceptance/01_virtualbox_spec.rb
@@ -3,11 +3,11 @@
 require 'spec_helper_acceptance'
 
 describe 'virtualbox class' do
-  virtualbox_versions = ['5.0', '5.1', '5.2', '6.0', '6.1']
+  virtualbox_versions = ['5.0', '5.1', '5.2', '6.0', '6.1', '7.0']
 
   test_from = case fact('os.name')
               when 'CentOS', 'RedHat'
-                '5.1'
+                '7.0'
               when 'Ubuntu'
                 case fact('os.release.major')
                 when '18.04'

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -92,9 +92,9 @@ describe 'virtualbox', type: :class do
       when 'RedHat'
         case facts[:os]['name']
         when 'Fedora'
-          it { is_expected.to contain_yumrepo('virtualbox').with_baseurl('https://download.virtualbox.org/virtualbox/rpm/fedora/$releasever/$basearch').with_gpgkey('https://www.virtualbox.org/download/oracle_vbox.asc') }
+          it { is_expected.to contain_yumrepo('virtualbox').with_baseurl('https://download.virtualbox.org/virtualbox/rpm/fedora/$releasever/$basearch').with_gpgkey('https://www.virtualbox.org/download/oracle_vbox_2016.asc') }
         else
-          it { is_expected.to contain_yumrepo('virtualbox').with_baseurl('https://download.virtualbox.org/virtualbox/rpm/el/$releasever/$basearch').with_gpgkey('https://www.virtualbox.org/download/oracle_vbox.asc') }
+          it { is_expected.to contain_yumrepo('virtualbox').with_baseurl('https://download.virtualbox.org/virtualbox/rpm/el/$releasever/$basearch').with_gpgkey('https://www.virtualbox.org/download/oracle_vbox_2016.asc') }
         end
 
         context 'with a custom version' do


### PR DESCRIPTION
#### Pull Request (PR) description
Newer versions of VirtualBox use a different signing key for the YUM repository.

https://www.virtualbox.org/wiki/Linux_Downloads
`As of VirtualBox 6.1.44/7.0.8, the same signing key as for Debian packages since 2016 is used.`

This will break installs of older packages from the repository, but I feel this is better than having an out of date module, and not worth the trouble of setting up the YUM repo different depending on the version someone wants to install.

#### This Pull Request (PR) fixes the following issues
Current versions of VirtualBox will not install from the configured YUM repository as is.
