### PR TITLE
Use modern APT keyrings on Debian family

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -46,8 +46,8 @@ class virtualbox::install (
           location     => 'https://download.virtualbox.org/virtualbox/debian',
           repos        => 'contrib',
           key          => {
-            'id'     => 'B9F8D658297AF3EFC18D5CDFA2F683C52980AECF',
-            'source' => 'https://www.virtualbox.org/download/oracle_vbox_2016.asc',
+            name   => 'virtualbox.asc',
+            source => 'https://www.virtualbox.org/download/oracle_vbox_2016.asc',
           },
         }
 

--- a/spec/classes/virtualbox_spec.rb
+++ b/spec/classes/virtualbox_spec.rb
@@ -70,7 +70,7 @@ describe 'virtualbox', type: :class do
       case facts[:os]['family']
       when 'Debian'
         it { is_expected.to contain_class('apt') }
-        it { is_expected.to contain_apt__source('virtualbox').with_location('https://download.virtualbox.org/virtualbox/debian').with_key('id' => 'B9F8D658297AF3EFC18D5CDFA2F683C52980AECF', 'source' => 'https://www.virtualbox.org/download/oracle_vbox_2016.asc') }
+        it { is_expected.to contain_apt__source('virtualbox').with_location('https://download.virtualbox.org/virtualbox/debian').with_key('name' => 'virtualbox.asc', 'source' => 'https://www.virtualbox.org/download/oracle_vbox_2016.asc') }
 
         context 'with a custom version' do
           let(:params) { { 'version' => '5.1' } }


### PR DESCRIPTION
This makes use of puppetlabs/puppetlabs-apt#1128 to store the public key
in `/etc/apt/keyrings` and add a `signed-by` option to the
`sources.list.d` entry.
