### PR TITLE
Namespace ensure_packages()

### DIFF
--- a/manifests/kernel.pp
+++ b/manifests/kernel.pp
@@ -14,7 +14,7 @@ class virtualbox::kernel (
   Array $vboxdrv_dependencies = $virtualbox::vboxdrv_dependencies,
   String $vboxdrv_command     = $virtualbox::vboxdrv_command
 ) {
-  ensure_packages($vboxdrv_dependencies)
+  stdlib::ensure_packages($vboxdrv_dependencies)
 
   exec { 'vboxdrv':
     command     => "${vboxdrv_command} setup",

--- a/metadata.json
+++ b/metadata.json
@@ -48,7 +48,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/apt",


### PR DESCRIPTION
The ensure_packages() function is deprecated and we should use
stdlib::ensure_packages() instead.
